### PR TITLE
Switch to smbus2 for I2C access

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A python module to interface with MS5837-30BA and MS5837-02BA waterproof pressur
 
 The python SMBus library must be installed.
 
-	sudo apt-get install python-smbus
+	sudo apt-get install python-smbus2
 
 Download this repository by clicking on the download button in this webpage, or using git:
 

--- a/ms5837/ms5837.py
+++ b/ms5837/ms5837.py
@@ -1,7 +1,7 @@
 try:
-    import smbus
+    import smbus2 as smbus
 except:
-    print('Try sudo apt-get install python-smbus')
+    print('Try sudo apt-get install python-smbus2')
     
 from time import sleep
 

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(
     author='Blue Robotics',
     url='https://github.com/bluerobotics/ms5837-python',
     packages=['ms5837'],
-    install_requires=['smbus'],
+    install_requires=['smbus2'],
 )


### PR DESCRIPTION
I've noticed for a project I'm working on currently, that the Python implementation to support this sensor uses the old smbus implementation considered to be outdated. In order to not introduce another dependency in my project I carefully migrated the code with as few changes as possible to use the more recent smbus2 implementation. 
 
- replaced outdated smbus dependency with more recent smbus2 version.
- modified imports and exception in the implementation itself
- changed readme and setup.py to reflect new installation dependencies